### PR TITLE
StringEntity will use UTF charset rather than the default ISO-8859-1

### DIFF
--- a/src/main/java/com/zuora/sdk/lib/ZAPI.java
+++ b/src/main/java/com/zuora/sdk/lib/ZAPI.java
@@ -17,6 +17,7 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntity;
@@ -130,7 +131,7 @@ public class ZAPI {
 
     // get a ssl pipe (httpclient), execute, trace response
     try {
-      StringEntity entity = new StringEntity(reqBody);
+      StringEntity entity = new StringEntity(reqBody, ContentType.APPLICATION_JSON);
       httpPut.setEntity(entity);
       ZAPIResp resp = tracePostAPIResponse(httpPut, sslPipe().execute(httpPut));
       httpPut.releaseConnection();
@@ -194,7 +195,7 @@ public class ZAPI {
            entity.addPart("params", new StringBody(reqParams));
         httpPost.setEntity( entity );
       } else {
-        StringEntity entity = new StringEntity(reqBody);
+        StringEntity entity = new StringEntity(reqBody, ContentType.APPLICATION_JSON);
         httpPost.setEntity(entity);
       }
       ZAPIResp resp =tracePostAPIResponse(httpPost, sslPipe().execute(httpPost));


### PR DESCRIPTION
Trying to `POST` and `PUT` payloads with UTF-8 characters such as ø or ß will not be parsed correctly by the API.

![screen shot 2016-10-18 at 9 28 23 am](https://cloud.githubusercontent.com/assets/1061456/19484565/477bc6a2-9515-11e6-876e-268d0bea0128.png)

The `StringEntity` class will default to ISO-8859-1, which is why an error related to byte-count is thrown.  `ContentType.APPLICATION_JSON` will use UTF
